### PR TITLE
make print statement python2/3 agnostic

### DIFF
--- a/chryswoods.com/beginning_python/loops.md
+++ b/chryswoods.com/beginning_python/loops.md
@@ -28,7 +28,7 @@ prints all of the even numbers from 0 to 200.
 for i in range(10, 0, -1):
     print("%d..." % i)
 
-print "We have lift off!"
+print ("We have lift off!")
 ```
 
 prints out a count down.


### PR DESCRIPTION
While testing the course examples in a python3 interpreter. 

>>> print "We have lift off!"
  File "<stdin>", line 1
    print "We have lift off!"
                            ^
SyntaxError: invalid syntax

Convert to python3 style

>>> print("We have lift off!")
We have lift off!